### PR TITLE
NO Merge  - Relax ActiveSupport and Rails restrictions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: .
   specs:
     webpacker (6.0.0.beta.7)
-      activesupport (>= 5.2)
+      activesupport (>= 5.0)
       rack-proxy (>= 0.6.1)
-      railties (>= 5.2)
+      railties (>= 5.0)
       semantic_range (>= 2.3.0)
 
 GEM

--- a/webpacker.gemspec
+++ b/webpacker.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.4.0"
 
-  s.add_dependency "activesupport", ">= 5.2"
-  s.add_dependency "railties",      ">= 5.2"
+  s.add_dependency "activesupport", ">= 5.0"
+  s.add_dependency "railties",      ">= 5.0"
   s.add_dependency "rack-proxy",    ">= 0.6.1"
   s.add_dependency "semantic_range", ">= 2.3.0"
 


### PR DESCRIPTION
Reduces contraints on ActiveSupport and railties starting range from 5.2 to 5.0.
This should enable 5.0 rails applications to have the latest webpacker application running without the need of a full rails upgrade.

Upgrade is still recommended when possible.

As of now, rake tasks for webpacker aren't being included.