### PR TITLE
Use single webpack config for rails/webpacker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ## [[6.0.0]](https://github.com/rails/webpacker/compare/v5.4.3...master) - 2021-TBD
 
 Please see [UPGRADE GUIDE](./docs/v6_upgrade.md) for more information.
-
+- Single default configuration file of `config/webpack/webpack.config.js`. Previously, the config file was set
+  to `config/webpack/#{NODE_ENV}.js`. 
 - `node_modules` will no longer be compiled by default. This primarily fixes [rails issue #35501](https://github.com/rails/rails/issues/35501) as well as [numerous other webpacker issues](https://github.com/rails/webpacker/issues/2131#issuecomment-581618497). The disabled loader can still be required explicitly via:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -272,10 +272,9 @@ end
 
 ### Webpack Configuration
 
-Webpacker gives you a default set of configuration files for test, development and production environments in `config/webpack/*.js`. You can configure each individual environment in their respective files or configure them all in the base
-`config/webpack/base.js` file.
+Webpacker gives you a default configuration file for your test, development, and production environments in `config/webpack/*.js`. 
 
-By default, you don't need to make any changes to `config/webpack/*.js` files since it's all standard production-ready configuration. However, if you do need to customize or add a new loader, this is where you would go.
+By default, you don't need to make any changes to `config/webpack/webpack.config.js` files since it's all standard production-ready configuration. However, if you do need to customize or add a new loader, this is where you would go.
 
 Here is how you can modify webpack configuration:
 
@@ -296,10 +295,10 @@ module.exports = {
 }
 ```
 
-Then `require` this file in your `config/webpack/base.js`:
+Then `require` this file in your `config/webpack/webpack.config.js`:
 
 ```js
-// config/webpack/base.js
+// config/webpack/webpack.config.js
 const { webpackConfig, merge } = require('@rails/webpacker')
 const customConfig = require('./custom')
 
@@ -309,7 +308,7 @@ module.exports = merge(webpackConfig, customConfig)
 If you need access to configs within Webpacker's configuration, you can import them like so:
 
 ```js
-// config/webpack/base.js
+// config/webpack/webpack.config.js
 const { webpackConfig } = require('@rails/webpacker')
 
 console.log(webpackConfig.output_path)
@@ -408,7 +407,7 @@ Add tsconfig.json
 Then modify the webpack config to use it as a plugin:
 
 ```js
-// config/webpack/base.js
+// config/webpack/webpack.config.js
 const { webpackConfig, merge } = require("@rails/webpacker");
 const ForkTSCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 
@@ -428,7 +427,7 @@ yarn add css-loader style-loader mini-css-extract-plugin css-minimizer-webpack-p
 Optionally, add the `CSS` extension to webpack config for easy resolution.
 
 ```js
-// config/webpack/base.js
+// config/webpack/webpack.config.js
 const { webpackConfig, merge } = require('@rails/webpacker')
 const customConfig = {
   resolve: {
@@ -501,7 +500,7 @@ module.exports = {
 ```
 
 ```js
-// config/webpack/base.js
+// config/webpack/webpack.config.js
 const { webpackConfig, merge } = require('@rails/webpacker')
 const vueConfig = require('./rules/vue')
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -128,7 +128,7 @@ Rails.application.config.assets.js_compressor = Uglifier.new(harmony: true)
 
 ### Angular: WARNING in ./node_modules/@angular/core/esm5/core.js, Critical dependency: the request of a dependency is an expression
 
-To silent these warnings, please update `config/webpack/base.js`:
+To silent these warnings, please update `config/webpack/webpack.config.js`:
 ```js
 const webpack = require('webpack')
 const { resolve } = require('path')
@@ -178,7 +178,7 @@ For instance, with [jQuery](https://jquery.com/):
 
 Instead do:
 ```js
-// config/webpack/base.js
+// config/webpack/webpack.config.js
 
 const webpack = require('webpack')
 const { webpackConfig, merge } = require('@rails/webpacker')

--- a/docs/v6_upgrade.md
+++ b/docs/v6_upgrade.md
@@ -11,49 +11,26 @@ Webpacker used to configure Webpack indirectly, which lead to a [complicated sec
 This means you have to configure integration with frameworks yourself, but webpack-merge helps with this. See this example for [Vue](https://github.com/rails/webpacker#other-frameworks) and scroll to the bottom for [more examples](#examples-of-v5-to-v6).
 
 ## How to upgrade to Webpacker v6 from v5
+1. Ensure you have a clean working git branch. You will be overwriting all your files and reverting the changes that you don't want.
 
-1. Consider changing from the v5 default for `source_entry_path`.
-  ```yml
-    source_path: app/javascript
-    source_entry_path: packs
-  ```
-  consider changing to the v6 default:
-  ```yml
-    source_path: app/javascript
-    source_entry_path: /
-  ```
-  Then consider moving your `app/javascript/packs/*` (including `application.js`) to `app/javascript/` and updating the configuration file. 
-  
-  Note, moving your files is optional, as you can stil keep your entries in a separate directory, called something like `packs`, or `entries`. This directory is defined within the source_path.
-  
-2. **Ensure no nested directories in your `source_entry_path`.** Check if you had any entry point files in child directories of your `source_entry_path`. Files for entry points in child directories are not supported by rails/webpacker v6. Move those files to the top level, adjusting any imports in those files.
-  
-  The new v6 configuration does not allow nesting, so as to allow placing the entry points at in the root directory of JavaScript. You can find this change [here](https://github.com/rails/webpacker/commit/5de0fbc1e16d3db0c93202fb39f5b4d80582c682#diff-7af8667a3e36201db57c02b68dd8651883d7bfc00dc9653661be11cd31feeccdL19).
+1. Upgrade the Webpacker Ruby gem and the NPM package
 
-3. Rename `config/webpack` to `config/webpack_old`
+   Note: [Check the releases page to verify the latest version](https://github.com/rails/webpacker/releases), and make sure to install identical version numbers of webpacker gem and `@rails/webpacker` npm package. (Gems use a period and packages use a dot between the main version number and the beta version.)
 
-4. Rename `config/webpacker.yml` to `config/webpacker_old.yml`
+   Example going to a specific version:
 
-5. Update `webpack-dev-server` to the current version, greater than 4.2, updating `package.json`.
+   ```ruby
+   # Gemfile
+   gem 'webpacker', '6.0.0.rc.7'
+   ```
 
-6. Upgrade the Webpacker Ruby gem and NPM package
+   ```bash
+   bundle install
+   ```
 
-Note: [Check the releases page to verify the latest version](https://github.com/rails/webpacker/releases), and make sure to install identical version numbers of webpacker gem and `@rails/webpacker` npm package. (Gems use a period and packages use a dot between the main version number and the beta version.)
-
-Example going to a specific version:
-
-  ```ruby
-  # Gemfile
-  gem 'webpacker', '6.0.0.rc.6'
-  ```
-
-  ```bash
-  bundle install
-  ```
-
-  ```bash
-  yarn add @rails/webpacker@6.0.0-rc.6 --exact
-  ```
+   ```bash
+   yarn add @rails/webpacker@6.0.0-rc.7 --exact
+   ```
 
   ```bash
   bundle exec rails webpacker:install
@@ -67,58 +44,94 @@ Example going to a specific version:
   yarn add @babel/core @babel/plugin-transform-runtime @babel/preset-env @babel/runtime babel-loader compression-webpack-plugin pnp-webpack-plugin terser-webpack-plugin webpack webpack-assets-manifest webpack-cli webpack-merge webpack-sources webpack-dev-server
   ```
 
-7. Update API usage of the view helpers by changing `javascript_packs_with_chunks_tag` and `stylesheet_packs_with_chunks_tag` to `javascript_pack_tag` and `stylesheet_pack_tag`. Ensure that your layouts and views will only have **at most one call** to `javascript_pack_tag` and **at most one call** to `stylesheet_pack_tag`. You can now pass multiple bundles to these view helper methods. If you fail to changes this, you may experience performance issues, and other bugs related to multiple copies of React, like [issue 2932](https://github.com/rails/webpacker/issues/2932).  If you expose jquery globally with `expose-loader,` by using `import $ from "expose-loader?exposes=$,jQuery!jquery"` in your `app/javascript/application.js`, pass the option `defer: false` to your `javascript_pack_tag`.
+1. There is now a single default configuration file of `config/webpack/webpack.config.js`. Previously, the config file was set
+  to `config/webpack/#{NODE_ENV}.js`. In the `config/webpack/` directory, you can either refactor your code in `test.js`, `development.js`, and `production.js` to a single file, `webpack.config.js` or you can replace the contents of `config/webpack/config.webpack.js` to conditionally load the old file based on the NODE_ENV with this snippet:
+   ```js
+   const { env, webpackConfig } = require('@rails/webpacker')
+   const { existsSync } = require('fs')
+   const { resolve } = require('path')
+   
+   const envSpecificConfig = () => {
+     const path = resolve(__dirname, `${env.nodeEnv}.js`)
+     if (existsSync(path)) {
+       console.log(`Loading ENV specific webpack configuration file ${path}`)
+       return require(path)
+     } else {
+       return webpackConfig
+     }
+   }
+   
+   module.exports = envSpecificConfig()
+   ```
+1. Review the new default's changes to `webpacker.yml`. Consider each suggested change carefully, especially the change to have your `source_entry_path` be at the top level of your `source_path`. 
+   The v5 default used `packs` for `source_entry_path`:
+   ```yml
+   source_path: app/javascript
+   source_entry_path: packs
+   ```
+   The v6 default uses the top level directory.
+   ```yml
+   source_path: app/javascript
+   source_entry_path: /
+   ```
+   If you prefer this configuratiom, then you will move your `app/javascript/packs/*` (including `application.js`) to `app/javascript/` and update the configuration file. 
+  
+   Note, moving your files is optional, as you can stil keep your entries in a separate directory, called something like `packs`, or `entries`. This directory is defined with the `source_path`.
+  
+1. **Ensure no nested directories in your `source_entry_path`.** Check if you had any entry point files in child directories of your `source_entry_path`. Files for entry points in child directories are not supported by rails/webpacker v6. Move those files to the top level, adjusting any imports in those files.
+  
+   The new v6 configuration does not allow nesting, so as to allow placing the entry points at in the root directory of JavaScript. You can find this change [here](https://github.com/rails/webpacker/commit/5de0fbc1e16d3db0c93202fb39f5b4d80582c682#diff-7af8667a3e36201db57c02b68dd8651883d7bfc00dc9653661be11cd31feeccdL19).
 
-8. If you are using any integrations like `css`, `postcss`, `React` or `TypeScript`. Please see https://github.com/rails/webpacker#integrations section on how they work in v6.
+1. Update `webpack-dev-server` to the current version, greater than 4.2, updating `package.json`.
 
-9. Copy over any custom webpack config from `config/webpack_old`. Common code previously called 'environment' should be changed to 'base', and import `environment` changed to `webpackConfig`.
+1. Update API usage of the view helpers by changing `javascript_packs_with_chunks_tag` and `stylesheet_packs_with_chunks_tag` to `javascript_pack_tag` and `stylesheet_pack_tag`. Ensure that your layouts and views will only have **at most one call** to `javascript_pack_tag` and **at most one call** to `stylesheet_pack_tag`. You can now pass multiple bundles to these view helper methods. If you fail to changes this, you may experience performance issues, and other bugs related to multiple copies of React, like [issue 2932](https://github.com/rails/webpacker/issues/2932).  If you expose jquery globally with `expose-loader,` by using `import $ from "expose-loader?exposes=$,jQuery!jquery"` in your `app/javascript/application.js`, pass the option `defer: false` to your `javascript_pack_tag`.
 
-  ```js
-  // config/webpack/base.js
-  const { webpackConfig, merge } = require('@rails/webpacker')
-  const customConfig = require('./custom')
+1. If you are using any integrations like `css`, `postcss`, `React` or `TypeScript`. Please see https://github.com/rails/webpacker#integrations section on how they work in v6.
 
-  module.exports = merge(webpackConfig, customConfig)
-  ```
+1. Import `environment` changed to `webpackConfig`. For example, the new code looks like:
+   ```js
+   // config/webpack/webpack.config.js
+   const { webpackConfig, merge } = require('@rails/webpacker')
+   const customConfig = require('./custom')
 
-10. Copy over custom browserlist config from `.browserslistrc` if it exists into the `"browserslist"` key in `package.json` and remove `.browserslistrc`.
+   module.exports = merge(webpackConfig, customConfig)
+   ```
 
-11. Remove `babel.config.js` if you never changed it. Be sure to have this config in your `package.json`:
+1. Copy over custom browserlist config from `.browserslistrc` if it exists into the `"browserslist"` key in `package.json` and remove `.browserslistrc`.
+
+1. Remove `babel.config.js` if you never changed it. Configure your `package.json` to use the default:
 
   ```json
   "babel": {
     "presets": [
-      "./node_modules/@rails/webpacker/package/babel/preset.js"
+      "./node_modules/webpackr/package/babel/preset.js"
     ]
   }
   ```
 See customization example the [Customizing Babel Config](./docs/customizing_babel_config.md) for React configuration.
 
-12. `extensions` was removed from the `webpacker.yml` file. Move custom extensions to your configuration by merging an object like this. For more details, see docs for [Webpack Configuration](https://github.com/rails/webpacker/blob/master/README.md#webpack-configuration)
+1. `extensions` was removed from the `webpacker.yml` file. Move custom extensions to your configuration by merging an object like this. For more details, see docs for [Webpack Configuration](https://github.com/rails/webpacker/blob/master/README.md#webpack-configuration)
 
-  ```js
-  {
-    resolve: {
-      extensions: ['.ts', '.tsx', '.vue', '.css']
+    ```js
+    {
+      resolve: {
+        extensions: ['.ts', '.tsx', '.vue', '.css']
+      }
     }
-  }
-  ```
+    ```
 
-13. Some dependencies were removed in [PR 3056](https://github.com/rails/webpacker/pull/3056). If you see the error: `Error: Cannot find module 'babel-plugin-macros'`, or similar, then you need to `yarn add <dependency>` where <dependency> might include: `babel-plugin-macros`, `case-sensitive-paths-webpack-plugin`, `core-js`, `regenerator-runtime`. Or you might want to remove your dependency on those.
+1. Some dependencies were removed in [PR 3056](https://github.com/rails/webpacker/pull/3056). If you see the error: `Error: Cannot find module 'babel-plugin-macros'`, or similar, then you need to `yarn add <dependency>` where <dependency> might include: `babel-plugin-macros`, `case-sensitive-paths-webpack-plugin`, `core-js`, `regenerator-runtime`. Or you might want to remove your dependency on those.
 
-14. If `bin/yarn` does not exist, create an executable [yarn](https://github.com/rails/webpacker/blob/master/lib/install/bin/yarn) file in your `/bin` directory.
+1. If `bin/yarn` did not exist, it was added.
 
-15. Remove overlapping dependencies from your `package.json` and rails/webpacker's `package.json`. For example, don't include `webpack` directly as that's a dependency of rails/webpacker.
-
-16. Review the new default's changes to `webpacker.yml` and `config/webpack`. Consider each suggested change carefully, especially the change to have your `source_entry_path` be at the top level of your `source_path`.
+1. Remove overlapping dependencies from your `package.json` and rails/webpacker's `package.json`. For example, don't include `webpack` directly as that's a dependency of rails/webpacker.
 
 17. Make sure that you can run `bin/webpacker` without errors.
+1. Try running `RAILS_ENV=production bin/rails assets:precompile`. If all goes well, don't forget to clean the generated assets with `bin/rails assets:clobber`.
 
-18. Try running `RAILS_ENV=production bin/rails assets:precompile`. If all goes well, don't forget to clean the generated assets with `bin/rails assets:clobber`.
+1. Run `yarn add webpack-dev-server` if those are not already in your dev dependencies. Make sure you're using v4+.
 
-19. Run `yarn add webpack-dev-server` if those are not already in your dev dependencies. Make sure you're using v4+.
-
-20. Try your app!
+1. Try your app!
 
 21. Update any scripts that called `/bin/webpack` or `bin/webpack-dev-server` to `/bin/webpacker` or `bin/webpacker-dev-server`
 

--- a/lib/install/config/webpack/base.js
+++ b/lib/install/config/webpack/base.js
@@ -1,3 +1,0 @@
-const { webpackConfig } = require('@rails/webpacker')
-
-module.exports = webpackConfig

--- a/lib/install/config/webpack/development.js
+++ b/lib/install/config/webpack/development.js
@@ -1,5 +1,0 @@
-process.env.NODE_ENV = process.env.NODE_ENV || 'development'
-
-const webpackConfig = require('./base')
-
-module.exports = webpackConfig

--- a/lib/install/config/webpack/production.js
+++ b/lib/install/config/webpack/production.js
@@ -1,5 +1,0 @@
-process.env.NODE_ENV = process.env.NODE_ENV || 'production'
-
-const webpackConfig = require('./base')
-
-module.exports = webpackConfig

--- a/lib/install/config/webpack/test.js
+++ b/lib/install/config/webpack/test.js
@@ -1,5 +1,0 @@
-process.env.NODE_ENV = process.env.NODE_ENV || 'development'
-
-const webpackConfig = require('./base')
-
-module.exports = webpackConfig

--- a/lib/install/config/webpack/webpack.config.js
+++ b/lib/install/config/webpack/webpack.config.js
@@ -1,0 +1,5 @@
+const { webpackConfig } = require('@rails/webpacker')
+
+// See the rails/webpacker README and docs directory for advice on customizing your webpackConfig.
+
+module.exports = webpackConfig

--- a/lib/webpacker/runner.rb
+++ b/lib/webpacker/runner.rb
@@ -11,7 +11,7 @@ module Webpacker
 
       @app_path              = File.expand_path(".", Dir.pwd)
       @node_modules_bin_path = ENV["WEBPACKER_NODE_MODULES_BIN_PATH"] || `yarn bin`.chomp
-      @webpack_config        = File.join(@app_path, "config/webpack/#{ENV["NODE_ENV"]}.js")
+      @webpack_config        = File.join(@app_path, "config/webpack/webpack.config.js")
       @webpacker_config      = ENV["WEBPACKER_CONFIG"] || File.join(@app_path, "config/webpacker.yml")
 
       unless File.exist?(@webpack_config)

--- a/package/index.js
+++ b/package/index.js
@@ -8,11 +8,12 @@ const baseConfig = require('./environments/base')
 const rules = require('./rules')
 const config = require('./config')
 const devServer = require('./dev_server')
-const { nodeEnv } = require('./env')
+const env = require('./env')
 const { moduleExists, canProcess } = require('./utils/helpers')
 const inliningCss = require('./inliningCss')
 
 const webpackConfig = () => {
+  const { nodeEnv } = env
   const path = resolve(__dirname, 'environments', `${nodeEnv}.js`)
   const environmentConfig = existsSync(path) ? require(path) : baseConfig
   return environmentConfig
@@ -23,6 +24,7 @@ module.exports = {
   devServer,
   webpackConfig: webpackConfig(),
   baseConfig,
+  env,
   rules,
   moduleExists,
   canProcess,

--- a/test/dev_server_runner_test.rb
+++ b/test/dev_server_runner_test.rb
@@ -15,25 +15,25 @@ class DevServerRunnerTest < Webpacker::Test
   end
 
   def test_run_cmd_via_node_modules
-    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/development.js"]
+    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
 
     verify_command(cmd, use_node_modules: true)
   end
 
   def test_run_cmd_via_yarn
-    cmd = ["yarn", "webpack", "serve", "--config", "#{test_app_path}/config/webpack/development.js"]
+    cmd = ["yarn", "webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
 
     verify_command(cmd, use_node_modules: false)
   end
 
   def test_run_cmd_argv
-    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/development.js", "--quiet"]
+    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--quiet"]
 
     verify_command(cmd, argv: ["--quiet"])
   end
 
   def test_run_cmd_argv_with_https
-    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/development.js", "--https"]
+    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--https"]
 
     dev_server = Webpacker::DevServer.new({})
     def dev_server.host; "localhost"; end
@@ -47,7 +47,7 @@ class DevServerRunnerTest < Webpacker::Test
   end
 
   def test_environment_variables
-    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/development.js"]
+    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
     env = Webpacker::Compiler.env.dup
     ENV["WEBPACKER_CONFIG"] = env["WEBPACKER_CONFIG"] = "#{test_app_path}/config/webpacker_other_location.yml"
     env["WEBPACK_SERVE"] = "true"

--- a/test/webpack_runner_test.rb
+++ b/test/webpack_runner_test.rb
@@ -13,19 +13,19 @@ class WebpackRunnerTest < Webpacker::Test
   end
 
   def test_run_cmd_via_node_modules
-    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "--config", "#{test_app_path}/config/webpack/development.js"]
+    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
 
     verify_command(cmd, use_node_modules: true)
   end
 
   def test_run_cmd_via_yarn
-    cmd = ["yarn", "webpack", "--config", "#{test_app_path}/config/webpack/development.js"]
+    cmd = ["yarn", "webpack", "--config", "#{test_app_path}/config/webpack/webpack.config.js"]
 
     verify_command(cmd, use_node_modules: false)
   end
 
   def test_run_cmd_argv
-    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "--config", "#{test_app_path}/config/webpack/development.js", "--watch"]
+    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "--config", "#{test_app_path}/config/webpack/webpack.config.js", "--watch"]
 
     verify_command(cmd, argv: ["--watch"])
   end


### PR DESCRIPTION
See original PR: https://github.com/rails/webpacker/pull/3240

# What?
Let's have the webpack config for rails/webpacker match [jsbundling-rails](https://github.com/rails/jsbundling-rails) and use `/webpack.config.js`.

# Why? 

## KISS, DRY

1. Simplicity and DRY. The default install was already cleaned up so
   there are no differences between installing test.js, development.js,
   and prododuction.js. This is just more clutter for people to dig
   through.
2. Avoid confusion. Most rails developers think about the RAILS_ENV.
   It's not at all obvious that old configuration file used was based on
   the NODE_ENV.  And what if you wanted to adjust the configuration based
   on the RAILS_ENV. Surely, you could have gotten confused. Additionally,
   the default of using NODE_ENV for building a Node file was also
   non-obvious.
3. Easy upgrade. The upgrade from using the old files to the new configuration only
   requires copy/pasting a few lines of code into the new configuration
   file.

## Demo of the migration
[Single change in shakacode/react_on_rails_tutorial_with_ssr_and_hmr_fast_refresh](https://github.com/shakacode/react_on_rails_tutorial_with_ssr_and_hmr_fast_refresh/pull/25/files#diff-a674a00764a4b25918469ea56a0afa43b552c149449929acd0d8e2c43f3f4e2d)

# Visual of the current, more complicated flow
Here is a clip from [my slides from my past RailsConf talk on the topic](https://www.shakacode.com/blog/railsconf-2020-webpacker-it-just-works-but-how/):

![image](https://user-images.githubusercontent.com/1118459/143788959-26ade42d-9ca6-4627-883c-24f90f6654ed.png)


